### PR TITLE
Add Android build GitHub workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,23 @@
+name: Android CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: gradle
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
## Summary
- automate Android build with GitHub Actions

## Testing
- `./gradlew help` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68692092e494832ab81864f901bac91e