### PR TITLE
Add APK artifact upload to Android CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,3 +21,8 @@ jobs:
         run: chmod +x gradlew
       - name: Build Debug APK
         run: ./gradlew assembleDebug
+      - name: Upload Debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: Xanite
+          path: app/build/outputs/apk/debug/Xanite.apk


### PR DESCRIPTION
## Summary
- upload the generated APK from the Android CI workflow

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a99c06f8832ab8a0aa378c0fb221